### PR TITLE
Allow cross-platform sharing of the ignore file.

### DIFF
--- a/src/pylint_ignore/__main__.py
+++ b/src/pylint_ignore/__main__.py
@@ -269,7 +269,7 @@ class PylintIgnoreDecorator:
         """
 
         pwd      = pl.Path(".").absolute()
-        rel_path = str(pl.Path(path).absolute().relative_to(pwd))
+        rel_path = str(pl.Path(path).absolute().relative_to(pwd).as_posix())
         if srctxt:
             source_line = srctxt.source_line
         else:


### PR DESCRIPTION
File paths will now be stored with forward-slashes on both windows and linux, so that the file can be shared using version control.

Fixes #6 