### PR TITLE
Fix pre-commit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To include `pylint-ignore` as a pre-commit hook using the provided plugin, add t
 
 ```yaml
   - repo: https://github.com/mbarkhau/pylint-ignore
-    rev: 2021.1020
+    rev: "2021.1024"
     hooks:
       - id: pylint-ignore
 ```


### PR DESCRIPTION
* `rev: 2021.1020` cannot be used for pre-commit;
  it doesn't have the necessary files - switch to the (newest) `2021.1024`
* The version scheme of the repository (`2021.1024`) is parsed
  by YAML as a float, instead of a string; quotes are explicitly needed

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>