### PR TITLE
Remove use of pathlib2

### DIFF
--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -37,4 +37,4 @@ lxml
 # yes, we depend on a previous version of ourselves
 #   (at least for integration purposes)
 pylint-ignore>=2020.1021
-pylint<2.12
+pylint==2.12.1

--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -9,5 +9,4 @@
 
 astroid>2.1.0
 pylint<2.13
-pathlib2
 pylev

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ warn_redundant_casts = True
 
 
 [tool:isort]
-known_third_party = pylint,click,pathlib2
+known_third_party = pylint,click
 force_single_line = True
 length_sort = True
 

--- a/src/pylint_ignore/__main__.py
+++ b/src/pylint_ignore/__main__.py
@@ -23,8 +23,8 @@ import tempfile
 import functools as ft
 import subprocess as sp
 import multiprocessing as mp
+import pathlib as pl
 
-import pathlib2 as pl
 import pylint.lint
 from pylint.lint.pylinter import PyLinter
 

--- a/src/pylint_ignore/__main__.py
+++ b/src/pylint_ignore/__main__.py
@@ -18,12 +18,12 @@ import typing as typ
 import getpass
 import hashlib
 import logging
+import pathlib as pl
 import datetime as dt
 import tempfile
 import functools as ft
 import subprocess as sp
 import multiprocessing as mp
-import pathlib as pl
 
 import pylint.lint
 from pylint.lint.pylinter import PyLinter

--- a/src/pylint_ignore/ignorefile.py
+++ b/src/pylint_ignore/ignorefile.py
@@ -8,8 +8,8 @@ import shutil
 import typing as typ
 import hashlib
 import logging
-import collections
 import pathlib as pl
+import collections
 
 import pylev
 

--- a/src/pylint_ignore/ignorefile.py
+++ b/src/pylint_ignore/ignorefile.py
@@ -9,9 +9,9 @@ import typing as typ
 import hashlib
 import logging
 import collections
+import pathlib as pl
 
 import pylev
-import pathlib2 as pl
 
 logger = logging.getLogger('pylint_ignore')
 

--- a/test/test_ignorefile.py
+++ b/test/test_ignorefile.py
@@ -2,18 +2,13 @@
 # pylint:disable=redefined-outer-name ; pytest.fixture tmp_ignorefile
 # pylint:disable=protected-access ; ok for testing
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import os
 import time
 import shutil
 import textwrap
+import pathlib as pl
 
 import pytest
-import pathlib2 as pl
 
 from pylint_ignore import ignorefile
 

--- a/test/test_ignorefile.py
+++ b/test/test_ignorefile.py
@@ -5,8 +5,8 @@
 import os
 import time
 import shutil
-import textwrap
 import pathlib as pl
+import textwrap
 
 import pytest
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -2,17 +2,12 @@
 # pylint:disable=redefined-outer-name ; pytest.fixture ignore_file
 # pylint:disable=protected-access ; ok for testing
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import os
 import sys
 import shutil
+import pathlib as pl
 
 import pytest
-import pathlib2 as pl
 
 import pylint_ignore.__main__ as main
 


### PR DESCRIPTION
pathlib has been included in the Python standard library since 3.4,
and since the lowest supported version of Python is now above that, we
can remove the external dependency and use pathlib directly. As a
drive-by, also remove a bunch of __future__ imports.