### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2022.1025
 
-- Pin pylint<1.13
+- Pin `pylint<2.13`
 
 Newer versions of pylint have different messages. Further work on
 pylint-ignore is discouraged in favor of work on integrating


### PR DESCRIPTION
`pylint<1.13` pin is wrong (PS: see https://github.com/mbarkhau/pylint-ignore/blob/7e04a5367c2b8f2624753797353c54a86a914900/requirements/pypi.txt#L11)